### PR TITLE
Unknown frame types throws an exception

### DIFF
--- a/lib/xbee-api.js
+++ b/lib/xbee-api.js
@@ -469,10 +469,10 @@ frames[C.FRAME_TYPE.ZIGBEE_IO_DATA_SAMPLE_RX] = {
 };
 
 // Unsupportet Frame Types
-for (key in C.FRAME_TYPES) {
-  var val = C.FRAME_TYPES[key];
+for (key in C.FRAME_TYPE) {
+  var val = C.FRAME_TYPE[key];
   if (typeof val === 'number') {
-    if (!frames.hasOwnProperty[val]) {
+    if (!frames[val]) {
       frames[val] = {
         parse: function(parser) {
           parser.json.not_implemented = true;


### PR DESCRIPTION
Unknown frame types throws an exception. The for loop for unsupported frames doesn't work.
