### PR TITLE
Catch uncaught exception when running AT command

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,11 @@ XBee.prototype.configure = function(_done_cb) {
     f = typeof f !== 'undefined' ? f : function(a){return a};
     return function(cb) {
       self._AT(command, val, function(err, data) {
-        cb(err, f(data.commandData)); 
+        if (!err) {
+          cb(err, f(data.commandData));
+        } else {
+          console.log('XBee.configure.QF - ', err.msg);
+        }
       });
     }
   }


### PR DESCRIPTION
For some reason when I used svd-xbee to interact with my XBee hardware it would throw this error and exit (code being run is examples/simple.js modified to point at my serial port):

```
timers.js:103
            if (!process.listeners('uncaughtException').length) throw e;
                                                                      ^
TypeError: Cannot read property 'commandData' of undefined
    at Object.XBee.configure.QF [as cb] (/Users/dan/housecarl/svd-xbee/index.js:136:23)
    at XBee.init (/Users/dan/housecarl/svd-xbee/index.js:116:47)
    at _asyncMap (/Users/dan/housecarl/svd-xbee/node_modules/async/lib/async.js:190:13)
    at async.forEachSeries.iterate (/Users/dan/housecarl/svd-xbee/node_modules/async/lib/async.js:110:21)
    at _asyncMap (/Users/dan/housecarl/svd-xbee/node_modules/async/lib/async.js:187:17)
    at async.series.results (/Users/dan/housecarl/svd-xbee/node_modules/async/lib/async.js:491:34)
    at Object._onTimeout (/Users/dan/housecarl/svd-xbee/index.js:205:7)
    at Timer.list.ontimeout (timers.js:101:19)
```

The attached code catches that exception, which I think occurs when an AT command returns an invalid value. Now when I run simple.js, I receive this output and node continues to run:

```
XBee.configure.QF -  Never got Transmit status from XBee
```

Let me know if the error should be handled in a different way. Thanks for the easy to use module!
