### PR TITLE
OOB error with Xbee.Send(Buffer )

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,8 +320,9 @@ XBee.prototype.send = function(data, remote64, remote16, _cb) {
     var frame = new api.TransmitRFData();
     frame.destination64 = remote64.dec;
     frame.destination16 = remote16.dec;
-    frame.RFData = data.slice(0, C.MAX_PAYLOAD_SIZE);
-    data = data.slice(C.MAX_PAYLOAD_SIZE);
+    var length = (C.MAX_PAYLOAD_SIZE < data.length) ? C.MAX_PAYLOAD_SIZE : data.length;
+    frame.RFData = data.slice(0,  length);
+    data = data.slice(length);
     packets.push(this._makeTask({
       data: frame.getBytes(),
       cbid: C.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS + C.EVT_SEP + frame.frameId

--- a/lib/xbee-api.js
+++ b/lib/xbee-api.js
@@ -254,7 +254,10 @@ TransmitRFData.prototype.getPayload = function() {
 
   if (this.RFData) {
     for(var j=0; j<this.RFData.length; j++) {
-      payload.push(this.RFData.charCodeAt(j));
+      if(Buffer.isBuffer(this.RFData))
+        payload.push(this.RFData[j]);
+      else
+        payload.push(this.RFData.charCodeAt(j));
     }
   }
 


### PR DESCRIPTION
In my application I create a packet on a Buffer, and then send it out. It seems that svd-xbee doesn't handle this very well.
Error: oob
    at Buffer.slice (buffer.js:553:26)
    at XBee.send (/home/bpaluch/projects/grid-react-gateway/node_modules/svd-bee/index.js:324:17)
    at Node.send (/home/bpaluch/projects/grid-react-gateway/node_modules/svd-xbee/index.js:528:13)
    at EventEmitter.<anonymous> (/home/bpaluch/projects/grid-react-gateway/libs/drivers/cordinator_xbee.js:34:14)
    at EventEmitter.emit (/home/bpaluch/projects/grid-react-gateway/node_modules/eventemitter2/lib/eventemitter2.js:332:22)

I've fixed it by testing for the length of the data being sliced in index.js, and then testing for Buffer type in xbee-api and using the Buffer value instead of the charCode. 

I really like the improvements you made this month! Thanks for making this awesome library.
