### PR TITLE
Fix for floating point numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -495,7 +495,7 @@ util.inherits(Node, EventEmitter);
 
 Node.prototype._onReceivePacket = function(packet) {
   // TODO: should be buffer all along!
-  var data = new Buffer(packet.rawData).toString('ascii');
+  var data = new Buffer(packet.rawData,'binary');
   if (this.xbee.use_heartbeat) {
     this.refreshTimeout();
     if (data === this.xbee.heartbeat_packet) return;


### PR DESCRIPTION
Casting data to ascii wreaks havoc later on when converting to binary.
I propose to keep it as Buffer for as long as possible.

I have written up a small pastebin explaining the problem:
http://pastebin.com/cTa1xgQQ
