### PR TITLE
Bug fix for an issue where the parser tries to start a new packet if the...

### DIFF
--- a/lib/xbee-api.js
+++ b/lib/xbee-api.js
@@ -293,6 +293,7 @@ exports.packetBuilder = function () {
   var running_total = 0;
   var checksum = -1;
   var escape_next = false;
+  var escaped = false;
 
   return function(emitter, buffer) {
     // Collecting data. 
@@ -307,12 +308,15 @@ exports.packetBuilder = function () {
       if (escape_next) {
         b = 0x20 ^ b;
         escape_next = false;
+        escaped = true;
       }
 
       packpos += 1; 
 
-      // Detected start of packet.
-      if (b == C.START_BYTE) {
+      // Detect start of packet, ONLY if this byte wasn't an escaped 0x7E (C.START_BYTE). The start
+      // delimeter will only be escaped if it is within the body of a packet, thus we shouldn't
+      // start a new packet if this value was escaped.
+      if (b == C.START_BYTE && !escaped) {
         packpos = 0;
         packlen = 0;
         running_total = 0;
@@ -320,6 +324,8 @@ exports.packetBuilder = function () {
         packet = [];
         escape_next = false;
       }
+
+      escaped = false;
 
       if (packpos == 1) packlen += b << 8; // most significant bit of the length
       if (packpos == 2) packlen += b;   // least significant bit of the length


### PR DESCRIPTION
... checksum equals 0x7E.

Thanks so much for this library! I know you are focusing efforts on the new `xbee-api` project now, but I wanted to contribute this fix for anyone who was still using this code for whatever reason (we still are!).

We found that anytime the checksum byte equaled 0x7E, our `data` event listeners weren't firing, due to the fact that 0x7E is the start delimiter. I simply added a flag to make sure a new packet starts only if the 0x7E value isn't escaped.

Thanks again!
