### PR TITLE
remove discover listener after discover timeout has elapsed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,13 +299,15 @@ XBee.prototype.addNode = function(remote64, remote16, parser) {
 XBee.prototype.discover = function(cb) {
   var self = this;
   var cbid = self._AT('ND');
-  self.serial.on(cbid, function(packet) {
+  var nodeIdentificationHandler = function(packet) {
     var node = parseNodeIdentificationPayload(packet.commandData);
     self._handleNodeIdentification(node);
-  })
+  }
+  self.serial.on(cbid, nodeIdentificationHandler);
   setTimeout(function() {
     if (typeof cb === 'function') cb(); 
     self.removeAllListeners(cbid);
+    self.serial.removeListener(cbid, nodeIdentificationHandler);
     self.emit("discoveryEnd");
   }, self.parameters.nodeDiscoveryTime || 6000);
 }


### PR DESCRIPTION
We realized that repeatedly calling `discover()` (which we do periodically) was causing the memory footprint to grow because some event listeners weren't getting freed up for garbage collection. You may prefer a different fix, but this seems to be working for us.

Thanks!
